### PR TITLE
add forms class to all part of speech sections

### DIFF
--- a/entry_processor.py
+++ b/entry_processor.py
@@ -23,11 +23,11 @@ class EntryProcessor:
 
         start_node = pos_spans[0].find_parent('blockquote')
         # Check the trigger *before* doing more work.
-        if 'forms' not in start_node.get_text(strip=True).lower():
+        if start_node is None or 'forms' not in start_node.get_text(strip=True).lower():
             return html
         end_node = pos_spans[1].find_parent('blockquote')
         # Guard against invalid start/end nodes to prevent uncontrolled loops.
-        if not start_node or not end_node or start_node is end_node:
+        if not end_node or start_node is end_node:
             return html
 
         # Collect all target nodes in a separate list before modifying the document.

--- a/style.css
+++ b/style.css
@@ -57,15 +57,19 @@ blockquote.etymology-notes {
 /* part of speech */
 .pos {
     color: #000000;
+    font-size: 1.1rem;
 }
 .major-division {
     color: #070707; /* was dark indigo 4B0082*/
+    font-size: 1.1rem;
 }
 .senses {
     color: #095c09; /* was dark indigo 4B0082*/
+    font-size: 1.1rem;
 }
 .subsenses {
     color:#008200; /* was dark indigo 4B0082*/
+    font-size: 1.1rem;
 }
 
 .kref {


### PR DESCRIPTION
### EntryProcessor Improvements:

* Added the `_process_pos_forms_section, which uses BeautifulSoup to identify and wrap non-styled sense/subsense block-quotes within "forms" sections, replacing the previous regex-based solution. 
* Updated the phonetic span substitution in the `process` method for more consistent formatting.
* Override inherited font size for `.pos`, `.major-division`, `.senses`, and `.subsenses` CSS classes to improve readability.